### PR TITLE
Add glab Ansible role for GitLab CLI

### DIFF
--- a/ansible/local_machine.yml
+++ b/ansible/local_machine.yml
@@ -60,6 +60,8 @@
       tags: [copilot_cli]
     - role: claude
       tags: [claude]
+    - role: glab
+      tags: [glab]
     - role: macos
       tags: [macos]
     - role: dotfiles

--- a/ansible/roles/glab/meta/main.yml
+++ b/ansible/roles/glab/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: homebrew

--- a/ansible/roles/glab/tasks/darwin.yml
+++ b/ansible/roles/glab/tasks/darwin.yml
@@ -1,0 +1,5 @@
+---
+- name: glab | darwin | install glab
+  community.general.homebrew:
+    name: glab
+    state: present

--- a/ansible/roles/glab/tasks/main.yml
+++ b/ansible/roles/glab/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: glab | darwin entrypoint
+  ansible.builtin.import_tasks: darwin.yml
+  when: ansible_facts['os_family'] == 'Darwin'
+
+- name: glab | unsupported platform placeholder
+  ansible.builtin.debug:
+    msg: "GitLab CLI role currently supports Darwin only."
+  when: ansible_facts['os_family'] != 'Darwin'


### PR DESCRIPTION
Install glab via Homebrew on Darwin, following the same single-formula role pattern as gemini_cli/copilot_cli.